### PR TITLE
Move Vision updates into separate thread using `Notifier`

### DIFF
--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -33,36 +33,31 @@ import frc.robot.subsystems.LocationService;
 import frc.robot.subsystems.Elevator.Elevator;
 import frc.robot.subsystems.LocationService.Offset;
 import frc.robot.subsystems.swervedrive.SwerveSubsystem;
-import frc.robot.subsystems.swervedrive.Vision;
-
 import java.io.File;
 import java.util.Set;
 import swervelib.SwerveInputStream;
 import frc.robot.subsystems.Output;
 
 /**
- * This class is where the bulk of the robot should be declared. Since
- * Command-based is a
- * "declarative" paradigm, very little robot logic should actually be handled in
- * the {@link Robot}
- * periodic methods (other than the scheduler calls). Instead, the structure of
- * the robot (including
+ * This class is where the bulk of the robot should be declared. Since Command-based is a
+ * "declarative" paradigm, very little robot logic should actually be handled in the {@link Robot}
+ * periodic methods (other than the scheduler calls). Instead, the structure of the robot (including
  * subsystems, commands, and trigger mappings) should be declared here.
  */
 @Logged
 public class RobotContainer {
 
-  private final ProfiledPIDController drivePoseAnglePIDController = new ProfiledPIDController(10.0, 0.0, 0.1,
-      new Constraints(1000, 10000));
+  private final ProfiledPIDController drivePoseAnglePIDController =
+      new ProfiledPIDController(10.0, 0.0, 0.1, new Constraints(1000, 10000));
   // Replace with CommandPS4Controller or CommandJoystick if needed
   final CommandXboxController driverXbox = new CommandXboxController(0);
   final CommandXboxController opXbox = new CommandXboxController(1);
   // The robot's subsystems and commands are defined here...
 
   private static final boolean useDrivebase = true;
-  private final SwerveSubsystem drivebase = useDrivebase
-      ? new SwerveSubsystem(new File(Filesystem.getDeployDirectory(), "swerve"))
-      : null;
+  private final SwerveSubsystem drivebase =
+      useDrivebase ? new SwerveSubsystem(new File(Filesystem.getDeployDirectory(), "swerve"))
+          : null;
 
   // private final Intake intake = new Intake(drivebase.getSwerveDrive());
 
@@ -93,8 +88,7 @@ public class RobotContainer {
   private final SendableChooser<Command> autoChooser;
 
   /**
-   * Converts driver input into a field-relative ChassisSpeeds that is controlled
-   * by angular
+   * Converts driver input into a field-relative ChassisSpeeds that is controlled by angular
    * velocity.
    */
   SwerveInputStream driveAngularVelocity = SwerveInputStream
@@ -104,22 +98,20 @@ public class RobotContainer {
       .scaleTranslation(0.8).allianceRelativeControl(true);
 
   SwerveInputStream driveAngularVelocityRed = SwerveInputStream
-      .of(drivebase.getSwerveDrive(), () -> driverXbox.getLeftY(),
-          () -> driverXbox.getLeftX())
+      .of(drivebase.getSwerveDrive(), () -> driverXbox.getLeftY(), () -> driverXbox.getLeftX())
       .withControllerRotationAxis(driverXbox::getRightX).deadband(OperatorConstants.DEADBAND)
       .scaleTranslation(0.8).allianceRelativeControl(true);
   /**
-   * Clone's the angular velocity input stream and converts it to a fieldRelative
-   * input stream.
+   * Clone's the angular velocity input stream and converts it to a fieldRelative input stream.
    */
   SwerveInputStream driveDirectAngle = driveAngularVelocity.copy()
       .withControllerHeadingAxis(driverXbox::getRightX, driverXbox::getRightY).headingWhile(true);
 
   /**
-   * Clone's the angular velocity input stream and converts it to a robotRelative
-   * input stream.
+   * Clone's the angular velocity input stream and converts it to a robotRelative input stream.
    */
-  SwerveInputStream driveRobotOriented = driveAngularVelocity.copy().robotRelative(true).allianceRelativeControl(false);
+  SwerveInputStream driveRobotOriented =
+      driveAngularVelocity.copy().robotRelative(true).allianceRelativeControl(false);
 
   SwerveInputStream driveAngularVelocityKeyboard = SwerveInputStream
       .of(drivebase.getSwerveDrive(), () -> -driverXbox.getLeftY(), () -> -driverXbox.getLeftX())
@@ -139,7 +131,8 @@ public class RobotContainer {
     return tagAutoPose2d;
   }
 
-  Command driveFieldOrientedAnglularVelocityKeyboardRed = drivebase.driveFieldOriented(driveAngularVelocityKeyboardRed);
+  Command driveFieldOrientedAnglularVelocityKeyboardRed =
+      drivebase.driveFieldOriented(driveAngularVelocityKeyboardRed);
 
   // Derive the heading axis with math!p\
   SwerveInputStream driveDirectAngleKeyboard = driveAngularVelocityKeyboard.copy()
@@ -180,18 +173,13 @@ public class RobotContainer {
   }
 
   /**
-   * Use this method to define your trigger->command mappings. Triggers can be
-   * created via the
-   * {@link Trigger#Trigger(java.util.function.BooleanSupplier)} constructor with
-   * an arbitrary
+   * Use this method to define your trigger->command mappings. Triggers can be created via the
+   * {@link Trigger#Trigger(java.util.function.BooleanSupplier)} constructor with an arbitrary
    * predicate, or via the named factories in
-   * {@link edu.wpi.first.wpilibj2.command.button.CommandGenericHID}'s subclasses
-   * for
+   * {@link edu.wpi.first.wpilibj2.command.button.CommandGenericHID}'s subclasses for
    * {@link CommandXboxController
-   * Xbox}/{@link edu.wpi.first.wpilibj2.command.button.CommandPS4Controller PS4}
-   * controllers or
-   * {@link edu.wpi.first.wpilibj2.command.button.CommandJoystick Flight
-   * joysticks}.
+   * Xbox}/{@link edu.wpi.first.wpilibj2.command.button.CommandPS4Controller PS4} controllers or
+   * {@link edu.wpi.first.wpilibj2.command.button.CommandJoystick Flight joysticks}.
    */
   private void configureBindings() {
 
@@ -200,7 +188,8 @@ public class RobotContainer {
     drivebase.driveFieldOriented(driveRobotOriented);
     drivebase.driveWithSetpointGeneratorFieldRelative(driveDirectAngle);
     drivebase.driveFieldOriented(driveDirectAngleKeyboard);
-    Command driveFieldOrientedAnglularVelocityKeyboard = drivebase.driveFieldOriented(driveAngularVelocityKeyboard);
+    Command driveFieldOrientedAnglularVelocityKeyboard =
+        drivebase.driveFieldOriented(driveAngularVelocityKeyboard);
 
     drivebase.driveWithSetpointGeneratorFieldRelative(driveDirectAngleKeyboard);
 


### PR DESCRIPTION
Appears to eliminate the issue of loop overruns (by ensuring the loop overruns occur only in the odometry update thread)